### PR TITLE
Add Terraform tests and CI for SNS

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -1,0 +1,27 @@
+name: Terraform
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform:
+    runs-on: ubuntu-latest
+    env:
+      AWS_ACCESS_KEY_ID: test
+      AWS_SECRET_ACCESS_KEY: test
+      AWS_REGION: us-east-1
+      AWS_EC2_METADATA_DISABLED: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "1.7.5"
+      - run: terraform fmt -check -recursive
+      - run: terraform init -backend=false
+      - run: terraform validate
+      - run: terraform test
+      - run: scripts/tf-test.sh

--- a/main.tftest.hcl
+++ b/main.tftest.hcl
@@ -1,0 +1,67 @@
+mock_provider "aws" {}
+
+run "default_topic" {
+  command = plan
+
+  variables {
+    name = "example"
+  }
+
+  assert {
+    condition     = aws_sns_topic.topic.name == "example"
+    error_message = "Topic name should default to the name variable."
+  }
+
+  assert {
+    condition     = aws_sns_topic.topic.tags.Name == "example"
+    error_message = "Topic Name tag should match the resolved topic name."
+  }
+}
+
+run "topic_prefix" {
+  command = plan
+
+  variables {
+    name         = "example"
+    topic_prefix = "events"
+  }
+
+  assert {
+    condition     = aws_sns_topic.topic.name == "example-events"
+    error_message = "Topic prefix should be appended to the name variable."
+  }
+}
+
+run "topic_name_override" {
+  command = plan
+
+  variables {
+    name                = "example"
+    topic_name_override = "explicit-topic"
+  }
+
+  assert {
+    condition     = aws_sns_topic.topic.name == "explicit-topic"
+    error_message = "Topic name override should be used as the topic name."
+  }
+}
+
+run "fifo_topic" {
+  command = plan
+
+  variables {
+    name                        = "example"
+    fifo_topic                  = true
+    content_based_deduplication = true
+  }
+
+  assert {
+    condition     = aws_sns_topic.topic.name == "example.fifo"
+    error_message = "FIFO topics should append the .fifo suffix."
+  }
+
+  assert {
+    condition     = aws_sns_topic.topic.content_based_deduplication == true
+    error_message = "FIFO topics should pass content-based deduplication through."
+  }
+}

--- a/test/basic-usage/basic-usage.tf
+++ b/test/basic-usage/basic-usage.tf
@@ -1,4 +1,7 @@
 provider "aws" {
+  skip_credentials_validation = true
+  skip_requesting_account_id  = true
+
   default_tags {
     tags = {
       environment = "dev"


### PR DESCRIPTION
## Summary
- add native Terraform plan tests for SNS topic naming and FIFO behavior
- add a public Terraform CI workflow for fmt, init, validate, and test

## Verification
- terraform fmt -check -recursive
- terraform init -backend=false
- terraform validate
- terraform test